### PR TITLE
add secp256k1 verification lib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,16 @@
+{
+  "extends": "solhint:recommended",
+  "rules": {
+    "no-inline-assembly": "off",
+    "no-unused-vars": "error",
+    "const-name-snakecase": "error",
+    "contract-name-camelcase": "error",
+    "event-name-camelcase": "error",
+    "func-name-mixedcase": "error",
+    "func-param-name-mixedcase": "error",
+    "modifier-name-mixedcase": "error",
+    "private-vars-leading-underscore": "error",
+    "var-name-mixedcase": "error",
+    "imports-on-top": "error"
+  }
+}

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.25 <0.7.0;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+}

--- a/contracts/mocks/Secp256k1.sol
+++ b/contracts/mocks/Secp256k1.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: TBD
+
+pragma solidity ^0.8.2;
+
+import "../utils/crypto/Secp256k1.sol";
+
+contract Secp256k1Mock {
+
+    function serializePubkey(
+        bytes memory pubkey,
+        bool prefix
+    ) public view returns (bytes memory) {
+        return Secp256k1.serializePubkey(pubkey, prefix);
+    }
+
+    function verify(bytes memory message, bytes memory publicKey, bytes memory sig) public view returns (bool) {
+        return Secp256k1.verify(message, publicKey, sig);
+    }
+
+    function recover(bytes memory message, bytes memory sig, uint8 v) public pure returns (address) {
+        (address recovered, ) = Secp256k1.tryRecover(sha256(message), sig, v);
+        return recovered;
+    }
+}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@chorusone/tendermint",
+  "description": "Tendermint library for Solidity",
+  "version": "4.3.2",
+  "files": [
+    "**/*.sol",
+    "/build/contracts/*.json",
+    "!/mocks/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ChorusOne/tendermint-sol.git"
+  },
+  "keywords": [
+    "tendermint",
+    "solidity"
+  ],
+  "author": "Mateusz Kaczanowski <mateusz@chorus.one>",
+  "license": "TBD",
+  "bugs": {
+    "url": "https://github.com/ChrousOne/tendermint-sol/issues"
+  },
+  "homepage": "https://chorus.one"
+}

--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: TBD
+pragma solidity ^0.8.2;
+
+library Bytes {
+    function toBytes32(bytes memory bz) internal pure returns (bytes32 ret) {
+        require(bz.length == 32, "Bytes: toBytes32 invalid size");
+        assembly {
+            ret := mload(add(bz, 32))
+        }
+    }
+
+    function toUint64(bytes memory _bytes, uint256 _start) internal pure returns (uint64 ret) {
+        require(_bytes.length >= _start + 8, "Bytes: toUint64 out of bounds");
+        assembly {
+            ret := mload(add(add(_bytes, 0x8), _start))
+        }
+    }
+
+    function toUint256(bytes memory _bytes, uint256 _start) internal pure returns (uint256) {
+        require(_bytes.length >= _start + 32, "Bytes: toUint256 out of bounds");
+        uint256 tempUint;
+
+        assembly {
+            tempUint := mload(add(add(_bytes, 0x20), _start))
+        }
+
+        return tempUint;
+    }
+
+	function toAddress(bytes memory _bytes) internal pure returns (address addr) {
+		// convert last 20 bytes of keccak hash (bytes32) to address
+		bytes32 hash = keccak256(_bytes);
+		assembly {
+			mstore(0, hash)
+			addr := mload(0)
+		}    
+	}
+}

--- a/contracts/utils/crypto/Secp256k1.sol
+++ b/contracts/utils/crypto/Secp256k1.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: TBD
+
+pragma solidity ^0.8.2;
+
+import "../Bytes.sol";
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+library Secp256k1 {
+    using Bytes for bytes;
+
+    uint private constant _PUBKEY_BYTES_LEN_COMPRESSED   = 33;
+    uint8 private constant _PUBKEY_COMPRESSED = 0x2;
+    uint8 private constant _PUBKEY_UNCOMPRESSED = 0x4;
+
+    /**
+     * @dev verifies the secp256k1 signature against the public key and message
+     * Tendermint uses RFC6979 and BIP0062 standard, meaning there is no recovery bit ("v" argument) present in the signature.
+     * The "v" argument is required by the ecrecover precompile (https://eips.ethereum.org/EIPS/eip-2098) and it can be either 0 or 1.
+     *
+     * To leverage the ecrecover precompile this method opportunisticly guess the "v" argument. At worst the precompile is called twice,
+     * which still might be cheaper than running the verification in EVM bytecode (as solidity lib)
+     *
+     * See: tendermint/crypto/secp256k1/secp256k1_nocgo.go (Sign, Verify methods)
+     */
+    function verify(bytes memory message, bytes memory publicKey, bytes memory signature) internal view returns (bool) {
+        address signer = Bytes.toAddress(serializePubkey(publicKey, false));
+        bytes32 hash = sha256(message);
+        (address recovered, ECDSA.RecoverError error) = tryRecover(hash, signature, 27);
+        if (error == ECDSA.RecoverError.NoError && recovered != signer) {
+            (recovered, error) = tryRecover(hash, signature, 28);
+        }
+
+        return error == ECDSA.RecoverError.NoError && recovered == signer;
+    }
+
+    /**
+     * @dev returns the address that signed the hash.
+     * This function flavor forces the "v" parameter instead of trying to derive it from the signature
+     *
+     * Source: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol#L56
+     */
+    function tryRecover(bytes32 hash, bytes memory signature, uint8 v) internal pure returns (address, ECDSA.RecoverError) {
+        if (signature.length == 65 || signature.length == 64) {
+            bytes32 r;
+            bytes32 s;
+            // ecrecover takes the signature parameters, and the only way to get them
+            // currently is to use assembly.
+            assembly {
+                r := mload(add(signature, 0x20))
+                s := mload(add(signature, 0x40))
+            }
+
+            return ECDSA.tryRecover(hash, v, r, s);
+        } else {
+            return (address(0), ECDSA.RecoverError.InvalidSignatureLength);
+        }
+    }
+
+    /**
+     * @dev check if public key is compressed (length and format)
+     */
+    function isCompressed(bytes memory pubkey) internal pure returns (bool) {
+        return pubkey.length == _PUBKEY_BYTES_LEN_COMPRESSED && uint8(pubkey[0]) & 0xfe == _PUBKEY_COMPRESSED;
+    }
+
+    /**
+     * @dev convert compressed PK to serialized-uncompressed format
+     */
+    function serializePubkey(bytes memory pubkey, bool prefix) internal view returns (bytes memory) {
+        require(isCompressed(pubkey), "Secp256k1: PK must be compressed");
+
+        uint8 yBit = uint8(pubkey[0]) & 1 == 1 ? 1 : 0;
+        uint256 x = Bytes.toUint256(pubkey, 1);
+        uint[2] memory xy = decompress(yBit, x);
+
+        if (prefix) {
+            return abi.encodePacked(_PUBKEY_UNCOMPRESSED, abi.encodePacked(xy[0]), abi.encodePacked(xy[1]));
+        }
+
+        return abi.encodePacked(abi.encodePacked(xy[0]), abi.encodePacked(xy[1]));
+    }
+
+    /**
+     * @dev decompress a point 'Px', giving 'Py' for 'P = (Px, Py)'
+     * 'yBit' is 1 if 'Qy' is odd, otherwise 0.
+     *
+     * Source: https://github.com/androlo/standard-contracts/blob/master/contracts/src/crypto/Secp256k1.sol#L82
+     */
+    function decompress(uint8 yBit, uint x) internal view returns (uint[2] memory point) {
+        uint p = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+        uint y2 = addmod(mulmod(x, mulmod(x, x, p), p), 7, p);
+        uint y_ = modexp(y2, (p + 1) / 4, p);
+        uint cmp = yBit ^ y_ & 1;
+        point[0] = x;
+        point[1] = (cmp == 0) ? y_ : p - y_;
+    }
+
+    /**
+     * @dev modular exponentiation via EVM precompile (0x05)
+     *
+     * Source: https://docs.klaytn.com/smart-contract/precompiled-contracts#address-0x05-bigmodexp-base-exp-mod
+     */
+    function modexp(uint base, uint exponent, uint modulus) internal view returns (uint result) {
+        assembly {
+            // free memory pointer
+            let memPtr := mload(0x40)
+
+            // length of base, exponent, modulus
+            mstore(memPtr, 0x20)
+            mstore(add(memPtr, 0x20), 0x20)
+            mstore(add(memPtr, 0x40), 0x20)
+
+            // assign base, exponent, modulus
+            mstore(add(memPtr, 0x60), base)
+            mstore(add(memPtr, 0x80), exponent)
+            mstore(add(memPtr, 0xa0), modulus)
+
+            // call the precompiled contract BigModExp (0x05)
+            let success := staticcall(gas(), 0x05, memPtr, 0xc0, memPtr, 0x20)
+            switch success
+            case 0 {
+                revert(0x0, 0x0)
+            } default {
+                result := mload(memPtr)
+            }
+        }
+    }
+}

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+const Migrations = artifacts.require("Migrations");
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations);
+};

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,0 +1,5 @@
+const Secp256k1Mock = artifacts.require("Secp256k1Mock");
+
+module.exports = function(deployer) {
+  deployer.deploy(Secp256k1Mock);
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@openzeppelin/contracts": "^4.3.2",
+    "truffle-assertions": "^0.9.2"
+  }
+}

--- a/test/utlis/crypto/Secp256k1.test.js
+++ b/test/utlis/crypto/Secp256k1.test.js
@@ -1,0 +1,77 @@
+const Secp256k1Mock = artifacts.require("Secp256k1Mock");
+const truffleAssert = require('truffle-assertions');
+
+
+contract('Secp256k1Mock', () => {
+
+  it('serializes compressed public key', async () => {
+    const mock = await Secp256k1Mock.deployed();
+    
+    const cases = [
+        {
+            pk: '0x02fc6c77e870eb482c4d7a0126cf528c3a6775f7fe3f291cbcd1dc0c3b7cc213ae',
+            expected: '0x04fc6c77e870eb482c4d7a0126cf528c3a6775f7fe3f291cbcd1dc0c3b7cc213ae107a10e61e384f16a3ef1273b55d354b4681774567e9499f21b7eb5f51eb528a'
+        },
+        {
+            pk: '0x0317088765d17a1232f9757ef7cf992046f383468de5e0e434379de1b8299039ff',
+            expected: '0x0417088765d17a1232f9757ef7cf992046f383468de5e0e434379de1b8299039ffcf73f4c9a35d4deb22114bdf5f3b6a6b7f5c985f5c21ef3dd68b722f9dd1ed43'
+        },
+        {
+            pk: '0x0317088765', // too short
+            expected: ''
+        },
+        {
+            pk: '0x0517088765d17a1232f9757ef7cf992046f383468de5e0e434379de1b8299039ff', // wrong prefix
+            expected: ''
+        },
+    ];
+
+    for (let c of cases) {
+        const serialized = mock.serializePubkey.call(c.pk, true);
+
+        if (c.expected.length) {
+            assert.equal(await serialized, c.expected, "invalid serialized public key");
+        } else {
+            await truffleAssert.reverts(serialized, "Secp256k1: PK must be compressed");
+        }
+    }
+  });
+
+  it('verifies secp256k1 signature', async () => {
+
+    const mock = await Secp256k1Mock.deployed();
+
+    const cases = [
+        {
+            msg: '0x6c080211140000000000000022480a201b234e2eb7fbd0045d30aff27f378f33bde4a93d7dff48e047e23dd64ea6551d122408011220ec9447ed497eeb1cdbe0121a8c7a449b84ac5d4b8618bb984b3e8206028d4f732a0b08d0f6ad8b0610daa4b3173208776f726d686f6c65',
+            sig: '0x051412327c5e160d767ef8b081c0e72f329130400b42553f4aa06a4d19397e395371ecd46c59eadc13a92e78fe420bf20bf55d608334981eb13a79ea266d9e28',
+            v: 28
+        },
+        {
+            msg: '0x6c080211080000000000000022480a20d892db02a8f682a8ecff369537f7f47672c1b73ae1dbfe234ebace17bfc0c3f412240801122098bf0b3e24565f0ccd182715619192f8df3ad2d447a62f5274bcaa8f3057731d2a0b08a2f2ad8b0610caabcd7c3208776f726d686f6c65',
+            sig: '0xb149b87d189c08f0ca164a5c0e4a28e6acfd0b745767a673905742ba9682a4a00d346b7a0a8b92f0d779b053c042a3ed0c7b5ca5a1e0b608e1aedeea395841d5',
+            v: 27
+        }
+    ];
+
+    // positive case
+    for (let c of cases) {
+        const pk = '0x0317088765d17a1232f9757ef7cf992046f383468de5e0e434379de1b8299039ff';
+        const verify = await mock.verify.call(c.msg, pk, c.sig);
+        const recovered = await mock.recover.call(c.msg, c.sig, c.v);
+
+        assert.equal(recovered, '0x083C31D442e15874407c8d9d17D17f26bf53ef34', "recovered invalid signer address");
+        assert.equal(verify, true, "secp256k1 signature verification failed");
+    }
+
+    // negative case
+    for (let c of cases) {
+        const pk = '0x0317088765d17a1232f9757ef7cf992046f383468de5e0e434379de1b8299039fe';
+        const verify = await mock.verify.call(c.msg, pk, c.sig);
+        const recovered = await mock.recover.call(c.msg, c.sig, c.v == 27 ? 28 : 27);
+
+        assert.notEqual(recovered, '0x083C31D442e15874407c8d9d17D17f26bf53ef34', "recovered address worked?");
+        assert.equal(verify, false, "secp256k1 verification should fail for wrong pk");
+    }
+  });
+});

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  compilers: {
+    solc: {
+      version: "0.8.2",
+      settings: {
+       optimizer: {
+         enabled: true,
+         runs: 2
+       },
+      }
+    }
+  }
+};


### PR DESCRIPTION
Tendermint might use secp256k1 signature, therefore we need to provide a function to verify the curve.