### PR TITLE
move trusted validators hash check to inner function

### DIFF
--- a/contracts/TendermintLightClient.sol
+++ b/contracts/TendermintLightClient.sol
@@ -168,21 +168,11 @@ contract TendermintLightClient is IClient {
         TmHeader.Data memory tmHeader,
         Duration.Data memory currentTime
     ) private view {
-        // checkTrustedHeader
-        // assert that trustedVals is NextValidators of last trusted header
-        // to do this, we check that trustedVals.Hash() == consState.NextValidatorsHash
-        require(
-            tmHeader.trusted_validators.hash() == trustedConsensusState.next_validators_hash.toBytes32(),
-            "LC: headers trusted validators does not hash to latest trusted validators"
-        );
-
 	    // assert header height is newer than consensus state
         require(
             tmHeader.signed_header.header.height > tmHeader.trusted_height,
             "LC: header height consensus state height"
         );
-
-        // TODO: IsRevisionFormat(chaiID)
 
         LightHeader.Data memory lc;
         lc.chain_id = clientState.chain_id;

--- a/contracts/utils/Tendermint.sol
+++ b/contracts/utils/Tendermint.sol
@@ -67,7 +67,6 @@ library Tendermint {
         );
 
         // Ensure that +2/3 of new validators signed correctly.
-        //if err := untrustedVals.VerifyCommitLight(trustedHeader.ChainID, untrustedHeader.Commit.BlockID,
         bool ok = verifyCommitLight(
             untrustedVals,
             trustedHeader.header.chain_id,
@@ -91,7 +90,14 @@ library Tendermint {
     ) internal view returns (bool) {
         require(
             untrustedHeader.header.height != trustedHeader.header.height + 1,
-            "headers must be non adjacent in height"
+            "LC: headers must be non adjacent in height"
+        );
+
+        // assert that trustedVals is NextValidators of last trusted header
+        // to do this, we check that trustedVals.Hash() == consState.NextValidatorsHash
+        require(
+            trustedVals.hash() == trustedHeader.header.next_validators_hash.toBytes32(),
+            "LC: headers trusted validators does not hash to latest trusted validators"
         );
 
         require(!trustedHeader.isExpired(trustingPeriod, currentTime), "header can't be expired");
@@ -102,7 +108,6 @@ library Tendermint {
         verifyCommitLightTrusting(trustedVals, trustedHeader.header.chain_id, untrustedHeader.commit, trustLevel);
 
         // Ensure that +2/3 of new validators signed correctly.
-        //if err := untrustedVals.VerifyCommitLight(trustedHeader.ChainID, untrustedHeader.Commit.BlockID,
         bool ok = verifyCommitLight(
             untrustedVals,
             trustedHeader.header.chain_id,

--- a/test/demo/src/main.rs
+++ b/test/demo/src/main.rs
@@ -276,7 +276,12 @@ async fn handle_header<'a, T: web3::Transport>(
         //.abci_query(Some(path), client_state_path.into_bytes(), Some(tendermint::block::Height::from(trusted_height as u32)), true)
         //.await.unwrap();
 
-        let trusted_validator_set = fetch_validator_set(client, trusted_height + 1, false).await?;
+        // sending trusted validators is required only for non-adjecent test,
+        // because tm_header.validator_set.hash() == consensusState.next_validators_hash (adjecent case)
+        let trusted_validator_set = match non_adjecent_test {
+            true => fetch_validator_set(client, trusted_height + 1, false).await?,
+            false => ValidatorSet::default(),
+        };
 
         let tm_header = TmHeader {
             signed_header: Some(signed_header.to_owned()),


### PR DESCRIPTION
Moving the trusted header into the inner call, makes the adjacent mode to run without having to pass the trusted validators (at trusted height) and therefore save some gas.

In the adjacent mode the validator set == consensusState.next_validators_hash